### PR TITLE
disable single sorting and set default sort order for OrderTable; for…

### DIFF
--- a/app/Http/Livewire/Backend/OrderTable.php
+++ b/app/Http/Livewire/Backend/OrderTable.php
@@ -33,6 +33,10 @@ class OrderTable extends DataTableComponent
         $this->setBulkActions([
             'syncAccurate' => 'Sync to Accurate',
         ]);
+
+        $this->setSingleSortingDisabled();
+
+        $this->setDefaultSort('created_at', 'desc');
     }
 
     public function filters(): array
@@ -105,8 +109,10 @@ class OrderTable extends DataTableComponent
             Column::make('Accurate Info', 'accurate_order_number')
                 ->format(fn($value, $row) => $value ? $value : "Not Synced"),
             Column::make("Created at", "created_at")
+                ->format(fn($value) => $value->diffForHumans())
                 ->sortable(),
             Column::make("Updated at", "updated_at")
+                ->format(fn($value) => $value->diffForHumans())
                 ->sortable(),
             Column::make("Actions")
                 ->label(fn($row, Column $column) => view('backend.order.includes.actions', ['order' => $row])),


### PR DESCRIPTION
This pull request includes enhancements to the `OrderTable` component in the backend. The changes focus on improving sorting and formatting functionalities.

Improvements to sorting:

* [`app/Http/Livewire/Backend/OrderTable.php`](diffhunk://#diff-c70639a65122241c8cc569f19e4085805fb79c88a92e2eb94864d12cec29db49R36-R39): Disabled single column sorting and set default sorting by `created_at` in descending order.

Enhancements to date formatting:

* [`app/Http/Livewire/Backend/OrderTable.php`](diffhunk://#diff-c70639a65122241c8cc569f19e4085805fb79c88a92e2eb94864d12cec29db49R112-R115): Added human-readable date formatting for `created_at` and `updated_at` columns using the `diffForHumans` method.…mat created and updated timestamps to display human-readable differences